### PR TITLE
Add basic sonar scanning support to zLUX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.scannerwork

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,6 @@
 sonar.projectKey=zlux
 sonar.projectName=Zlux Superproject
 sonar.projectVersion=0.9.3
-sonar.modules=explorer-server-auth,sample-angular-app,sample-iframe-app,sample-react-app,tn3270-ng2,vt-ng2,zlux-app-manager,zlux-editor,zlux-example-server,
-              zlux-ng2,zlux-platform,zlux-proxy-server,zlux-shared-zlux-workflow,zos-subsystems,zosmf-auth,zss-auth
+sonar.modules=explorer-server-auth,sample-angular-app,sample-iframe-app,sample-react-app,\
+            tn3270-ng2,vt-ng2,zlux-app-manager,zlux-editor,zlux-example-server,zlux-platform,\
+            zlux-proxy-server,zlux-shared,zlux-workflow,zos-subsystems,zosmf-auth,zss-auth

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,5 @@
+sonar.projectKey=zlux
+sonar.projectName=Zlux Superproject
+sonar.projectVersion=0.9.3
+sonar.modules=explorer-server-auth,sample-angular-app,sample-iframe-app,sample-react-app,tn3270-ng2,vt-ng2,zlux-app-manager,zlux-editor,zlux-example-server,
+              zlux-ng2,zlux-platform,zlux-proxy-server,zlux-shared-zlux-workflow,zos-subsystems,zosmf-auth,zss-auth


### PR DESCRIPTION
These changes are minimal viable configurations to allow sonar to scan zlux and its submodules. 

There are corresponding PRs in each of the zlux submodules for the sonar-scanner property files. 

The sonar scan itself and system-specific configuration takes place within Jenkins build & config definitions.
