### PR TITLE
Bugfix for zos charset encoding

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,53 @@
+# This .gitattributes file will cause all text files EXCEPT for
+# git's .gitattributes and .gitignore files to be encoded as EBCDIC.
+# Selected binary files will not be translated at all.
+# The default for text files
+*       git-encoding=iso8859-1 zos-working-tree-encoding=ibm-1047
+# git's files (which MUST be ASCII)
+.gitattributes   git-encoding=iso8859-1 zos-working-tree-encoding=iso8859-1
+.gitignore       git-encoding=iso8859-1 zos-working-tree-encoding=iso8859-1
+# Binary files, selected by file extension.
+#
+# Note that "Binary" really just means "Not touched when moved
+# between the git repository and the working tree." In some cases
+# these are actually UTF-8 or CP1251 (the usual Windows code page).
+#
+# If you don't have these in your tree, removing these from the
+# .gitattributes file will speed up git's processing a bit.
+#
+# While it would make sense to have BINARY be BINARY on all platforms,
+# Other platforms don't use the BINARY term, But do recognize "binary" macro
+*.jpg   git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.crx   git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.eot   git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.fdt   git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.fdx   git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.gen   git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.gif   git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.gz    git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.ico   git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.jar   git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.jpg   git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.node  git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.otf   git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.png   git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.PNG   git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.resources   git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.scss  git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.segments_1   git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.so    git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.svg   git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.swp   git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.tar   git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.tgz   git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.tii   git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.tis   git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.tree  git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.ttf   git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.woff  git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.woff2 git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.zip   git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+# Always use LF for npm package files because npm cli likes to change line endings.
+package*.json text eol=lf
+# sonar scanning
+sonar-project.properties git-encoding=iso8859-1 zos-working-tree-encoding=iso8859-1


### PR DESCRIPTION
In Git 2.18 for platforms other than z/os, support was added for a statement in .gitattributes files, `working-tree-encoding`, which overlapped in purpose and name with a command on git for z/os. This command is used to checkout files as a certain encoding that may differ from what is stored within git. On z/os, it is convenient to have many text files checked out as EBCDIC, but many other platforms don't have the tooling to convert to EBCDIC, nor would they want to as most editors do not interpret EBCDIC. Therefore, in git 2.18, use of `working-tree-encoding` for z/os needs is broken.
As a result, z/os git version 2.14 has added support for `zos-working-tree-encoding`, as a way to have conditional behavior based on OS. 

**In this series of PRs, all the zlux repositories that were making use of `working-tree-encoding` in `.gitattributes` are being switched to `zos-working-tree-encoding`.**
**After this PR, git 2.18 and above can be used on non-z/os platforms, while z/os will need git version 2.14 or newer.**

**NOTE: zlux superproject pointers in this commit are not pointing to the commits for the same fix in each submodule, but it will be updated post-merge of submodules.**
Resolves https://github.com/zowe/zlux/issues/61

Does not depend upon, but should have the following submodules PRs approved:
https://github.com/zowe/explorer-server-auth/pull/6
https://github.com/zowe/sample-angular-app/pull/11
https://github.com/zowe/sample-iframe-app/pull/9
https://github.com/zowe/sample-react-app/pull/8
https://github.com/zowe/tn3270-ng2/pull/12
https://github.com/zowe/vt-ng2/pull/10
https://github.com/zowe/zlux-app-manager/pull/72
https://github.com/zowe/zlux-build/pull/11
https://github.com/zowe/zlux-editor/pull/18
https://github.com/zowe/zlux-example-server/pull/31
https://github.com/zowe/zlux-ng2/pull/2
https://github.com/zowe/zlux-platform/pull/19
https://github.com/zowe/zlux-proxy-server/pull/47
https://github.com/zowe/zlux-shared/pull/7
https://github.com/zowe/zlux-workflow/pull/22
https://github.com/zowe/zos-subsystems/pull/14
https://github.com/zowe/zosmf-auth/pull/8
https://github.com/zowe/zss-auth/pull/6