### PR TITLE
Adding schema for server config and plugindefinition

### DIFF
--- a/schema/config-schema.json
+++ b/schema/config-schema.json
@@ -1,0 +1,659 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "$id": "https://github.com/zowe/zlux/zlux.schema.json",
+  "title": "app-server configuration",
+  "description": "Configuration properties for the app-server, as specified within a configuration file such as zowe.yaml",
+  "type": "object",
+  "required": [ "productDir", "siteDir", "instanceDir", "groupsDir", "usersDir", "pluginsDir", "dataserviceAuthentication", "node" ],
+  "properties": {
+    "node": {
+      "type": "object",
+      "description": "Configuration options specific to the app-server and things it depends upon",
+      "properties": {
+        "https": {
+          "type": "object",
+          "properties": {
+            "port": {
+              "$ref": "#/$defs/tcpPort",
+              "default": 8554
+            },
+            "pfx": {
+              "type": "string",
+              "deprecated": true,
+              "description": "Replaced with use of .p12 files within the key or certificate sections, this attribute was used to load certificates from a .pfx file"
+            },
+            "keys": {
+              "$ref": "#/$defs/certObject"
+            },
+            "certificates": {
+              "$ref": "#/$defs/certObject"
+            },
+            "certificateAuthorities": {
+              "$ref": "#/$defs/certObject"
+            },
+            "certificateRevocationLists": {
+              "$ref": "#/$defs/certObject"
+            },
+            "secureOptions": {
+              "type": "integer",
+              "description": "Controls nodejs' use of OpenSSL via integers composed of the values in the references https://github.com/openssl/openssl/blob/master/include/openssl/ssl.h and https://nodejs.org/api/crypto.html#openssl-options"
+            },
+            "secureProtocol": {
+              "type": "string",
+              "deprecated": true,
+              "description": "Passes through the secureProtocol attribute to TLS calls of nodeJS, as defined within https://nodejs.org/api/tls.html#tlscreatesecurecontextoptions"
+            },
+            "ciphers": {
+              "oneOf": [
+                { "$ref": "#/$defs/nodejsDefaultCiphers" },
+                { "$ref": "#/$defs/zoweDefaultCiphers" },
+                { "$ref": "#/$defs/customCiphers" }
+              ]
+            },
+            "enableTrace": {
+              "type": "boolean",
+              "default": false
+            },
+            "passphrase": {
+              "type": "string",
+              "description": "Used to load encrypted key or certificate objects when needed"
+            },
+            "ipAddresses": {
+              "$ref": "#/$defs/ipsAndHostnames",
+              "default": [ "0.0.0.0" ]
+            }
+          }
+        },
+        "http": {
+          "type": "object",
+          "description": "Allows the app-server to run in HTTP mode. This should never be done without a TLS wrapper such as AT-TLS",
+          "properties": {
+            "port": {
+              "$ref": "#/$defs/tcpPort"
+            },
+            "ipAddresses": {
+              "$ref": "#/$defs/ipsAndHostnames"
+            }
+          }
+        },
+        "mediationLayer": {
+          "type": "object",
+          "description": "Properties relating to how the app-server should interact with and find the API Mediation Layer components",
+          "properties": {
+            "server": {
+              "type": "object",
+              "properties": {
+                "isHttps": {
+                  "type": "boolean",
+                  "description": "Controls if connections to the API Mediation Layer gateway and/or discovery service should be HTTP or HTTPS"
+                },
+                "gatewayHostname": {
+                  "type": "string",
+                  "format": "hostname",
+                  "description": "The hostname or IP where the Zowe Gateway service is running. When not specified, the hostname property is used instead"
+                },
+                "hostname": {
+                  "type": "string",
+                  "format": "hostname",
+                  "description": "The hostname or IP where the Zowe Discovery service is running"
+                },
+                "gatewayPort": {
+                  "$ref": "#/$defs/tcpPort",
+                  "description": "The port where the Zowe Gateway service is running"
+                },
+                "port": {
+                  "$ref": "#/$defs/tcpPort",
+                  "description": "The port where the Zowe Discovery service is running"
+                },
+                "enabled": {
+                  "type": "boolean",
+                  "description": "Controls whether the app-server should register to the Zowe API Mediation Layer as a Eureka Client"
+                },
+                "cachingService": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean",
+                      "description": "Controls whether the app-server storage API can store in the caching service"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "internalRouting": {
+          "type": "boolean",
+          "description": "Controls if app-server should call one REST API from another by using a network call over a loopback address, or issue the request internal to the server by mimicking a network request",
+          "default": false
+        },
+        "allowInvalidTLSProxy": {
+          "type": "boolean",
+          "description": "This boolean sets the inverse value of the nodeJS attribute 'rejectUnauthorized' on any TLS operation within the server. It will allow connections with certificates that cannot be validated for one reason or another.",
+          "default": false
+        },
+        "childProcesses": {
+          "type": "array",
+          "description": "The app-server can start one or more processes as children of itself, and propagate signals sent to the app server to these. This can be used to start related servers at the same time as the app-server.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "path": {
+                "type": "string",
+                "description": "The command to be started via the process spawn() command"
+              },
+              "once": {
+                "type": "boolean",
+                "description": "When true, the child process will only be started from one worker rather than per-worker as would happen in cluster mode otherwise.",
+                "default": false
+              }
+            }
+          }
+        },
+        "session": {
+          "type": "object",
+          "properties": {
+            "timeoutMS": {
+              "type": "integer",
+              "deprecated": true,
+              "description": "No longer read by app-server"
+            },
+            "cookie": {
+              "timeoutMS": {
+                "type": "integer",
+                "description": "Determines the expiration time of the app-server cookie. This does not control other cookies such as ZSS, APIML. The experation time is shown in the /auth response, not as a cookie property. The cookie does not expire but will be rejected after the server expiration time.",
+                "default": -1
+              }
+            }
+          }
+        },
+        "headers": {
+          "type": "object",
+          "description": "Allows customization of http response headers sent by all plugins except those headers that are set as 'override' within a plugin. Each attribute in the object is a header name.",
+          "patternProperties": {
+            "content-security-policy": {
+              "$ref": "#/$defs/headerCustomization",
+              "preset": {
+                "oneOf": [
+                  { "$ref": "#/$defs/cspPresetStrict" },
+                  { "$ref": "#/$defs/cspPresetFrameStrict" }
+                ]
+              }
+            },
+            "^.*$": {
+              "$ref": "#/$defs/headerCustomization"
+            }
+          }
+        },
+        "pluginScanIntervalSec": {
+          "type": "integer",
+          "description": "When set above 0, the app-server will scan pluginsDir every number of seconds to look for plugins to add, allowing you to install new plugins without restarting the server. Note this does not allow upgrade or removal, which need restart or RBAC-controlled management REST API invocation",
+          "default": 0
+        },
+        "rootRedirectURL": {
+          "type": "string",
+          "description": "The URL which the server will redirect to if a request is sent to '/'",
+          "default": "/ZLUX/plugins/org.zowe.zlux.bootstrap/web/"
+        },
+        "noPrompt": {
+          "type": "boolean",
+          "description": "Whether to prompt for a passphrase when a passphrase is needed but not found for a pfx object",
+          "default": false
+        },
+        "noChild": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether the childProcesses array should be skipped on startup."
+        },
+        "loopbackAddress": {
+          "description": "The address the app-server should use to contact itself if a loopback request is needed by a call() operation from a plugin",
+          "$ref": "#/$defs/ipOrHostname"
+        },
+        "hostname": {
+          "type": "string",
+          "format": "hostname",
+          "description": "When not specified, the nodejs value of os.hostname() is used. This value is used to tell clients and other servers the location of the app-server."
+        }
+      }
+    },
+    "agent": {
+      "type": "object",
+      "description": "Configuration options specific to app-server agents, such as ZSS. These options are used to configure the agent, but also to tell app-server about the agent configuration",
+      "properties": {
+        "host": {
+          "type": "string",
+          "description": "Tells app-server which hostname or ip to communicate with the agent at"
+        },
+        "https": {
+          "type": "object",
+          "description": "Configures the agent to use HTTPS.",
+          "properties": {
+            "port": {
+              "$ref": "#/$defs/tcpPort",
+              "default": 8542
+            },
+            "ipAddresses": {
+              "$ref": "#/$defs/ipsAndHostnames",
+              "default": [ "0.0.0.0" ]
+            }
+          }
+        },
+        "http": {
+          "type": "object",
+          "description": "Configures the agent to use HTTP. When using AT-TLS, this object should be defined but with http.attls=true. It is insecure and absolutely not recommended to use http without AT-TLS",
+          "properties": {
+            "port": {
+              "$ref": "#/$defs/tcpPort"
+            },
+            "attls": {
+              "type": "boolean",
+              "default": false,
+              "description": "Tells the app-server whether or not the agent should be reached using HTTPS or HTTP when contacting the HTTP port"
+            },
+            "ipAddresses": {
+              "$ref": "#/$defs/ipsAndHostnames"
+            }
+          }
+        },
+        "mediationLayer": {
+          "type": "object",
+          "properties": {
+            "serviceName": {
+              "type": "string",
+              "description": "What the agent will be named when found on the API Mediation Layer"
+            },
+            "enabled": {
+              "type": "boolean",
+              "description": "Controls whether the agent should register to the API Mediation Layer, and whether the app-server should contact it via the Mediation Layer"
+            }
+          }
+        },
+        "handshakeTimeout": {
+          "type": "integer",
+          "default": 30000,
+          "description": "The timeout in milliseconds on the startup check the app-server will do to find its agent and check agent capabilities"
+        },
+        "jwt": {
+          "type": "object",
+          "properties": {
+            "fallback": {
+              "type": "boolean",
+              "description": "Whether the agent will issue and accept cookies from itself in the event a JWT cannot be provided"
+            }
+          }
+        }
+      }
+    },
+    "productDir": {
+      "type": "string",
+      "description": "The location of the product scope of the configuration dataservice"
+    },
+    "siteDir": {
+      "type": "string",
+      "description": "The location of the site scope of the configuration dataservice"
+    },
+    "instanceDir": {
+      "type": "string",
+      "description": "The location of the instance scope of the configuration dataservice"
+    },
+    "groupsDir": {
+      "type": "string",
+      "description": "The location of the groups scope of the configuration dataservice"
+    },
+    "usersDir": {
+      "type": "string",
+      "description": "The location of the user scope of the configuration dataservice"
+    },
+    "pluginsDir": {
+      "type": "string",
+      "description": "The location where plugin locator JSON files are found, which are used by the app-server and agent to locate and use plugins"
+    },
+    "dataserviceAuthentication": {
+      "type": "object",
+      "description": "Describes how the app-server will utilize the auth plugins it finds and loads at startup",
+      "properties": {
+        "rbac": {
+          "type": "boolean",
+          "description": "Determines whether or not the app-server will issue authorization requests to the authentication plugins for each HTTP(S) request to achieve Role Based Access Control",
+          "default": false
+        },
+        "defaultAuthentication": {
+          "type": "string",
+          "description": "Instructs the app-server which authentication category to issue auth requests to if a specific one was not specified by the caller or plugin",
+          "default": "fallback"
+        },
+        "implementationDefaults": {
+          "type": "object",
+          "deprecated": true,
+          "patternProperties": {
+            "^.*$": {
+              "type": "object",
+              "properties": {
+                "plugins": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/$defs/reverseDomainNotation"
+                  },
+                  "uniqueItems": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "logLevels": {
+      "type": "object",
+      "patternProperties": {
+        "_zsf.bootstrap": {
+          "description": "Logging that pertains to the startup of the server.",
+          "$ref": "#/$defs/logLevel"
+        },
+        "_zsf.auth": {
+          "description": "Logging for network calls that must be checked for authentication and authorization purposes.",
+          "$ref": "#/$defs/logLevel"
+        },
+        "_zsf.static": {
+          "description": "Logging of the serving of static files (such as images) from an application's /web folder.",
+          "$ref": "#/$defs/logLevel"
+        },
+        "_zsf.child": {
+          "description": "Logging of child processes, if any.",
+          "$ref": "#/$defs/logLevel"
+        },
+        "_zsf.utils": {
+          "description": "Logging for miscellaneous utilities that the server relies upon.",
+          "$ref": "#/$defs/logLevel"
+        },
+        "_zsf.proxy": {
+          "description": "Logging for proxies that are set up in the server.",
+          "$ref": "#/$defs/logLevel"
+        },
+        "_zsf.install": {
+          "description": "Logging for the installation of plug-ins.",
+          "$ref": "#/$defs/logLevel"
+        },
+        "_zsf.apiml": {
+          "description": "Logging for communication with the api mediation layer.",
+          "$ref": "#/$defs/logLevel"
+        },
+        "_zsf.routing": {
+          "description": "Logging for dispatching network requests to plug-in dataservices.",
+          "$ref": "#/$defs/logLevel"
+        },
+        "_zsf.network": {
+          "description": "Logging for the HTTPS server status (connection, ports, IP, and so on)",
+          "$ref": "#/$defs/logLevel"
+        },
+        "_zss.traceLevel": {
+          "description": "Controls general server logging verbosity.",
+          "$ref": "#/$defs/logLevel"
+        },
+        "_zss.fileTrace": {
+          "description": "Logs file serving behavior (if file serving is enabled).",
+          "$ref": "#/$defs/logLevel"
+        },
+        "_zss.socketTrace": {
+          "description": "Logs general TCP Socket behavior.",
+          "$ref": "#/$defs/logLevel"
+        },
+        "_zss.httpParseTrace": {
+          "description": "Logs parsing of HTTP messages.",
+          "$ref": "#/$defs/logLevel"
+        },
+        "_zss.httpDispatchTrace": {
+          "description": "Logs dispatching of HTTP messages to dataservices.",
+          "$ref": "#/$defs/logLevel"
+        },
+        "_zss.httpHeadersTrace": {
+          "description": "Logs parsing and setting of HTTP headers.",
+          "$ref": "#/$defs/logLevel"
+        },
+        "_zss.httpSocketTrace": {
+          "description": "Logs TCP socket behavior for HTTP.",
+          "$ref": "#/$defs/logLevel"
+        },
+        "_zss.httpCloseConversationTrace": {
+          "description": "Logs HTTP behavior for when an HTTP conversation ends.",
+          "$ref": "#/$defs/logLevel"
+        },
+        "_zss.httpAuthTrace": {
+          "description": "Logs behavior for session security.",
+          "$ref": "#/$defs/logLevel"
+        },
+        "^.*$": {
+          "$ref": "#/$defs/logLevel"
+        }
+      }
+    },
+    "logLanguage": {
+      "type": "string",
+      "default": "en"
+    },
+    "languages": {
+      "properties": {
+        "java": {
+          "type": "object",
+          "properties": {
+            "portRange": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/tcpPort",
+                "minItems": 2,
+                "maxItems": 2
+              }
+            },
+            "ports": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/tcpPort",
+                "uniqueItems": true
+              }
+            },
+            "jar": {
+              "type": "object",
+              "properties": {
+                "runtimes": {
+
+                },
+                "runtimeMapping": {
+
+                }
+              }
+            },
+            "war" : {
+              "type": "object",
+              "required": [ "javaAppServer" ],
+              "properties": {
+                "pluginGrouping": {
+                  "type": "array",
+                  "description": "A list of which java plugins should run in which java runtimes. If not present, all will run from one runtime",
+                  "items": {
+                    "type": "object",
+                    "required": [ "plugins" ],
+                    "properties": {
+                      "java": {
+                        "type": "string"
+                      },
+                      "plugins": {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/$defs/reverseDomainNotation"
+                        }
+                      }
+                    }
+                  }
+                },
+                "defaultGrouping": {
+                  "type": "string",
+                  "description": "Determines whether services should be grouped together in as few processes as possible or run as 1 process per service",
+                  "enum": [ "microservice", "appserver" ]
+                },
+                "javaAppServer": {
+                  "type": "object",
+                  "propeties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [ "tomcat" ]
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "config": {
+                      "type": "string",
+                      "description": "The file path to the appserver config file"
+                    },
+                    "https": {
+                      "type": "object",
+                      "properties": {
+                        "key": {
+                          "$ref": "#/$defs/pathCertObject"
+                        },
+                        "certificate": {
+                          "$ref": "#/$defs/pathCertObject"
+                        },
+                        "certificateChain": {
+                          "$ref": "#/$defs/pathCertObject"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "runtimes": {
+              "type": "object",
+              "patternProperties": {
+                "^.*$": {
+                  "type": "object",
+                  "required": [ "home" ],
+                  "properties": {
+                    "home": {
+                      "type": "string",
+                      "description": "The path of the runtime's home directory"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "instanceID": {
+      "type": "string",
+      "description": "The ID used in determining which set of RBAC resources to verify during authorization"
+    },
+    "privilegedServerName": {
+      "type": "string",
+      "description": "The nickname of the ZIS server to be used"
+    }
+  },
+  "$defs": {
+    "reverseDomainNotation": {
+      "type": "string",
+      "pattern": "^[A-Za-z]{2,6}((?!-)\\.[A-Za-z0-9-]{1,63}(?<!-))+$"
+    },
+    "nodejsDefaultCiphers": {
+      "const": "NODEJS",
+      "description": "Instructs app-server to use the default cipher list of nodejs when using TLS"
+    },
+    "zoweDefaultCiphers": {
+      "const": "",
+      "description": "Instructs app-server to use its default cipher list when using TLS"
+    },
+    "customCiphers": {
+      "type": "string",
+      "not": {
+        "anyOf": [
+          { "$ref": "#/$defs/nodejsDefaultCiphers" },
+          { "$ref": "#/$defs/zoweDefaultCiphers" }
+        ]
+      },
+      "description": "Instructs app-server to use the list of ciphers in this string when using TLS. String must be in the form defined here https://nodejs.org/api/tls.html#modifying-the-default-tls-cipher-suite"
+    },
+    "ipv4": {
+      "type": "string",
+      "pattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$"
+    },
+    "ipOrHostname": {
+      "type": "string"
+    },
+    "ipsAndHostnames": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/ipOrHostname"
+      },
+      "uniqueItems": true
+    },
+    "headerCustomization": {
+      "type": "object",
+      "properties": {
+        "substitutions": {
+          "type": "object",
+          "patternProperties": {
+            "^.*$": {
+              "oneOf": [
+                { "$ref": "#/$defs/headerSubstituteDomain" }
+              ]
+            }
+          }
+        }
+      }
+    },
+    "headerSubstituteDomain": {
+      "const": "domain",
+      "description": "Substitute the variable referenced with the value of the domain seen on the request"
+    },
+    "certObject": {
+      "type": "array",
+      "description": "The location of a file or keyring object",
+      "items": {
+        "anyOf": [
+          { "$ref": "#/$defs/fileCertObject" },
+          { "$ref": "#/$defs/pathCertObject" },
+          { "$ref": "#/$defs/safKeyringCertObject" }
+        ]
+      },
+      "uniqueItems": true
+    },
+    "fileCertObject": {
+      "type": "string",
+      "pattern": "^file:\/\/.*$"
+    },
+    "safKeyringCertObject": {
+      "type": "string",
+      "pattern": "^safkeyring:(\/\/)+.*$"
+    },
+    "pathCertObject": {
+      "type": "string",
+      "not": {
+        "anyOf": [
+          { "pattern": "^file:\/\/.*$" },
+          { "pattern": "^safkeyring:(\/\/)+.*$" }
+        ]
+      }
+    },
+    "cspPresetStrict": {
+      "const": "strict",
+      "description": "Applies builtin value 'default-src self req.hostname'"
+    },
+    "cspPresetFrameStrict": {
+      "const": "frame-strict",
+      "description": "Applies builtin value 'frame-src self req.hostname'"
+    },
+    "tcpPort": {
+      "type": "integer",
+      "description": "TCP network port",
+      "minimum": 1,
+      "maximum": 65535
+    },
+    "logLevel": {
+      "type": "integer",
+      "description": "Log level verbosity where 0 is least verbose (errors only), 5 is most verbose (trace) and 2 is default (info)",
+      "default": 2,
+      "minimum": 0,
+      "maximum": 5
+    }
+  }
+}

--- a/schema/config-schema.json
+++ b/schema/config-schema.json
@@ -5,17 +5,23 @@
   "description": "Configuration properties for the app-server, as specified within a configuration file such as zowe.yaml",
   "type": "object",
   "required": [ "productDir", "siteDir", "instanceDir", "groupsDir", "usersDir", "pluginsDir", "dataserviceAuthentication", "node" ],
+  "additionalProperties": false,
   "properties": {
     "node": {
       "type": "object",
       "description": "Configuration options specific to the app-server and things it depends upon",
+      "additionalProperties": false,
       "properties": {
         "https": {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
             "port": {
-              "$ref": "#/$defs/tcpPort",
-              "default": 8554
+              "oneOf": [
+                { "$ref": "#/$defs/tcpPort" },
+                { "$ref": "#/$defs/reservedTcpPort" }, 
+              ],
+              "default": 7556
             },
             "pfx": {
               "type": "string",
@@ -36,7 +42,7 @@
             },
             "secureOptions": {
               "type": "integer",
-              "description": "Controls nodejs' use of OpenSSL via integers composed of the values in the references https://github.com/openssl/openssl/blob/master/include/openssl/ssl.h and https://nodejs.org/api/crypto.html#openssl-options"
+              "description": "Controls nodejs' use of OpenSSL via integers composed of the values in the references https://github.com/openssl/openssl/blob/master/include/openssl/ssl.h.in and https://nodejs.org/api/crypto.html#openssl-options"
             },
             "secureProtocol": {
               "type": "string",
@@ -67,9 +73,13 @@
         "http": {
           "type": "object",
           "description": "Allows the app-server to run in HTTP mode. This should never be done without a TLS wrapper such as AT-TLS",
+          "additionalProperties": false,
           "properties": {
             "port": {
-              "$ref": "#/$defs/tcpPort"
+              "oneOf": [
+                { "$ref": "#/$defs/tcpPort" },
+                { "$ref": "#/$defs/reservedTcpPort" }, 
+              ]
             },
             "ipAddresses": {
               "$ref": "#/$defs/ipsAndHostnames"
@@ -79,9 +89,11 @@
         "mediationLayer": {
           "type": "object",
           "description": "Properties relating to how the app-server should interact with and find the API Mediation Layer components",
+          "additionalProperties": false,
           "properties": {
             "server": {
               "type": "object",
+              "additionalProperties": false,
               "properties": {
                 "isHttps": {
                   "type": "boolean",
@@ -98,11 +110,17 @@
                   "description": "The hostname or IP where the Zowe Discovery service is running"
                 },
                 "gatewayPort": {
-                  "$ref": "#/$defs/tcpPort",
+                  "oneOf": [
+                    { "$ref": "#/$defs/tcpPort" },
+                    { "$ref": "#/$defs/reservedTcpPort" }, 
+                  ],
                   "description": "The port where the Zowe Gateway service is running"
                 },
                 "port": {
-                  "$ref": "#/$defs/tcpPort",
+                  "oneOf": [
+                    { "$ref": "#/$defs/tcpPort" },
+                    { "$ref": "#/$defs/reservedTcpPort" }, 
+                  ],
                   "description": "The port where the Zowe Discovery service is running"
                 },
                 "enabled": {
@@ -111,6 +129,7 @@
                 },
                 "cachingService": {
                   "type": "object",
+                  "additionalProperties": false,
                   "properties": {
                     "enabled": {
                       "type": "boolean",
@@ -137,6 +156,7 @@
           "description": "The app-server can start one or more processes as children of itself, and propagate signals sent to the app server to these. This can be used to start related servers at the same time as the app-server.",
           "items": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
               "path": {
                 "type": "string",
@@ -152,6 +172,7 @@
         },
         "session": {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
             "timeoutMS": {
               "type": "integer",
@@ -219,6 +240,7 @@
     "agent": {
       "type": "object",
       "description": "Configuration options specific to app-server agents, such as ZSS. These options are used to configure the agent, but also to tell app-server about the agent configuration",
+      "additionalProperties": false,
       "properties": {
         "host": {
           "type": "string",
@@ -227,10 +249,14 @@
         "https": {
           "type": "object",
           "description": "Configures the agent to use HTTPS.",
+          "additionalProperties": false,
           "properties": {
             "port": {
-              "$ref": "#/$defs/tcpPort",
-              "default": 8542
+              "oneOf": [
+                { "$ref": "#/$defs/tcpPort" },
+                { "$ref": "#/$defs/reservedTcpPort" }, 
+              ],
+              "default": 7557
             },
             "ipAddresses": {
               "$ref": "#/$defs/ipsAndHostnames",
@@ -241,9 +267,13 @@
         "http": {
           "type": "object",
           "description": "Configures the agent to use HTTP. When using AT-TLS, this object should be defined but with http.attls=true. It is insecure and absolutely not recommended to use http without AT-TLS",
+          "additionalProperties": false,
           "properties": {
             "port": {
-              "$ref": "#/$defs/tcpPort"
+              "oneOf": [
+                { "$ref": "#/$defs/tcpPort" },
+                { "$ref": "#/$defs/reservedTcpPort" }, 
+              ]
             },
             "attls": {
               "type": "boolean",
@@ -257,6 +287,7 @@
         },
         "mediationLayer": {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
             "serviceName": {
               "type": "string",
@@ -275,6 +306,7 @@
         },
         "jwt": {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
             "fallback": {
               "type": "boolean",
@@ -311,6 +343,7 @@
     "dataserviceAuthentication": {
       "type": "object",
       "description": "Describes how the app-server will utilize the auth plugins it finds and loads at startup",
+      "additionalProperties": false,
       "properties": {
         "rbac": {
           "type": "boolean",
@@ -328,6 +361,7 @@
           "patternProperties": {
             "^.*$": {
               "type": "object",
+              "additionalProperties": false,
               "properties": {
                 "plugins": {
                   "type": "array",
@@ -421,6 +455,34 @@
           "description": "Logs behavior for session security.",
           "$ref": "#/$defs/logLevel"
         },
+        "_zss.mvdserver": {
+          "description": "Generic logging for ZSS items not covered by other loggers",
+          "$ref": "#/$defs/logLevel"
+        },
+        "_zss.ctds": {
+          "description": "Controls logging of the built-in CTDS service",
+          "$ref": "#/$defs/logLevel"
+        },
+        "_zss.security": {
+          "description": "Controls logging of the built-in security service",
+          "$ref": "#/$defs/logLevel"
+        },
+        "_zss.unixfile": {
+          "description": "Controls logging of the built-in unixfile service",
+          "$ref": "#/$defs/logLevel"
+        },
+        "_zss.dataservice": {
+          "description": "Controls logging of generic dataservice tasks",
+          "$ref": "#/$defs/logLevel"
+        },
+        "_zss.apimlstorage": {
+          "description": "Controls logging of the dataservice storage API",
+          "$ref": "#/$defs/logLevel"
+        },
+        "_zss.jwk": {
+          "description": "Controls logging of JWK use for SSO",
+          "$ref": "#/$defs/logLevel"
+        },
         "^.*$": {
           "$ref": "#/$defs/logLevel"
         }
@@ -431,14 +493,19 @@
       "default": "en"
     },
     "languages": {
+      "additionalProperties": false,
       "properties": {
         "java": {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
             "portRange": {
               "type": "array",
               "items": {
-                "$ref": "#/$defs/tcpPort",
+                "anyOf": [
+                  { "$ref": "#/$defs/tcpPort" },
+                  { "$ref": "#/$defs/reservedTcpPort" }, 
+                ],
                 "minItems": 2,
                 "maxItems": 2
               }
@@ -446,7 +513,10 @@
             "ports": {
               "type": "array",
               "items": {
-                "$ref": "#/$defs/tcpPort",
+                "anyOf": [
+                  { "$ref": "#/$defs/tcpPort" },
+                  { "$ref": "#/$defs/reservedTcpPort" }, 
+                ],
                 "uniqueItems": true
               }
             },
@@ -464,6 +534,7 @@
             "war" : {
               "type": "object",
               "required": [ "javaAppServer" ],
+              "additionalProperties": false,
               "properties": {
                 "pluginGrouping": {
                   "type": "array",
@@ -471,6 +542,7 @@
                   "items": {
                     "type": "object",
                     "required": [ "plugins" ],
+                    "additionalProperties": false,
                     "properties": {
                       "java": {
                         "type": "string"
@@ -505,6 +577,7 @@
                     },
                     "https": {
                       "type": "object",
+                      "additionalProperties": false,
                       "properties": {
                         "key": {
                           "$ref": "#/$defs/pathCertObject"
@@ -527,6 +600,7 @@
                 "^.*$": {
                   "type": "object",
                   "required": [ "home" ],
+                  "additionalProperties": false,
                   "properties": {
                     "home": {
                       "type": "string",
@@ -554,6 +628,20 @@
       "type": "string",
       "pattern": "^[A-Za-z]{2,6}((?!-)\\.[A-Za-z0-9-]{1,63}(?<!-))+$"
     },
+    "ipv4": {
+      "type": "string",
+      "pattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$"
+    },
+    "ipOrHostname": {
+      "type": "string"
+    },
+    "ipsAndHostnames": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/ipOrHostname"
+      },
+      "uniqueItems": true
+    },
     "nodejsDefaultCiphers": {
       "const": "NODEJS",
       "description": "Instructs app-server to use the default cipher list of nodejs when using TLS"
@@ -572,22 +660,9 @@
       },
       "description": "Instructs app-server to use the list of ciphers in this string when using TLS. String must be in the form defined here https://nodejs.org/api/tls.html#modifying-the-default-tls-cipher-suite"
     },
-    "ipv4": {
-      "type": "string",
-      "pattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$"
-    },
-    "ipOrHostname": {
-      "type": "string"
-    },
-    "ipsAndHostnames": {
-      "type": "array",
-      "items": {
-        "$ref": "#/$defs/ipOrHostname"
-      },
-      "uniqueItems": true
-    },
     "headerCustomization": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "substitutions": {
           "type": "object",
@@ -645,8 +720,15 @@
     "tcpPort": {
       "type": "integer",
       "description": "TCP network port",
-      "minimum": 1,
+      "minimum": 1024,
       "maximum": 65535
+    },
+    "reservedTcpPort": {
+      "type": "integer",
+      "description": "Reserved TCP network ports. Can be used but discouraged due to their standardized use by common programs",
+      "deprecated": true,
+      "minimum": 1,
+      "maximum": 1023
     },
     "logLevel": {
       "type": "integer",

--- a/schema/plugindefinition-schema.json
+++ b/schema/plugindefinition-schema.json
@@ -1,0 +1,480 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "$id": "https://github.com/zowe/zlux/plugin.schema.json",
+  "title": "Application Framework Plugin Definition",
+  "description": "Properties seen in a pluginDefinition.json file which describes a plugin of the Zowe Application Framework",
+  "type": "object",
+  "oneOf": [
+    { "$ref": "#/$defs/bootstrapPlugin" },
+    { "$ref": "#/$defs/desktopPlugin" },
+    { "$ref": "#/$defs/libraryPlugin" },
+    { "$ref": "#/$defs/applicationPlugin" },
+    { "$ref": "#/$defs/nodeAuthenticationPlugin" }
+  ],
+  "$defs": {
+    "reverseDomainNotation": {
+      "type": "string",
+      "pattern": "^[A-Za-z]{2,6}((?!-)\\.[A-Za-z0-9-]{1,63}(?<!-))+$"
+    },
+    "appFwPlugin": {
+      "type": "object",
+      "required": ["identifier", "apiVersion", "pluginVersion", "pluginType"],
+      "additionalProperties": true,
+      "propeties": {
+        "identifier": {
+          "$ref": "#/$defs/reverseDomainNotation",
+          "description": "Each plugin must have a zowe-wide unique ID in reverse domain name notation"
+        },
+        "apiVersion": {
+          "$ref": "#/$defs/semverVersion",
+          "description": "Describes which version of this schema the plugin is compatible with"
+        },
+        "pluginVersion": {
+          "$ref": "#/$defs/semverVersion",
+          "description": "Describes the plugin's version. The app-server only runs 1 version of each plugin."
+        },
+        "pluginType": {
+          "type": "string",
+          "enum": [ "bootstrap", "desktop", "library", "application", "nodeAuthentication" ]
+        },
+        "license": {
+          "type": "string",
+          "description": "An SPDX string describing which license the plugin is available under"
+        },
+        "author": {
+          "type": "string",
+          "description": "States who the writers of the plugin are"
+        },
+        "homepage": {
+          "type": "string",
+          "description": "A website URL of the writers of the plugin"
+        },
+        "requirements": {
+          "type": "object",
+          "description": "TODO",
+          "properties": {
+            "components": {
+              "type": "object",
+              "patternProperties": {
+                "^.*$": {
+                  "type": "object",
+                  "properties": {
+                    "os": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "description": "An OS type as reported by nodejs os.platform()"
+                      }
+                    },
+                    "cpu": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "description": "A CPU architecture type as reported by nodejs os.arch()"
+                      }
+                    },
+                    "version": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/$defs/semverRange"
+                      }
+                    },
+                    "endpoints": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "dataServices": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              { "$ref": "#/$defs/routerService" },
+              { "$ref": "#/$defs/serviceService" },
+              { "$ref": "#/$defs/importService" },
+              { "$ref": "#/$defs/externalService" },
+              { "$ref": "#/$defs/nodeService" }
+            ]
+          },
+          "uniqueItems": true
+        },
+        "configurationData": {
+          "type": "object",
+          "description": "TODO",
+          "properties": {
+            "resources": {
+              "type": "object"
+            }
+          }
+        }
+      }
+    },
+    "bootstrapPlugin": {
+      "$ref": "#/$defs/appFwPlugin",
+      "properties": {
+        "pluginType": {
+          "const": "bootstrap"
+        },
+        "webContent": {
+          "$ref": "#/$defs/genericWebContent"
+        }
+      }
+    },
+    "desktopPlugin": {
+      "$ref": "#/$defs/appFwPlugin",
+      "properties": {
+        "pluginType": {
+          "const": "desktop"
+        },
+        "webContent": {
+          "$ref": "#/$defs/nativeWebContent"
+        }
+      }
+    },
+    "applicationPlugin": {
+      "$ref": "#/$defs/appFwPlugin",
+      "properties": {
+        "pluginType": {
+          "const": "application"
+        },
+        "webContent": {
+          "type": "object",
+          "oneOf": [
+            { "$ref": "#/$defs/iframeWebContent" },
+            { "$ref": "#/$defs/genericWebContent" },
+            { "$ref": "#/$defs/nativeWebContent" }
+          ]
+        },
+        "isSystemPlugin": {
+          "type": "boolean",
+          "default": false,
+          "description": "Set this to true to make a plugin that cannot be opened directly by users, but may be invoked by other apps and the application framework itself via app2app communication as needed."
+        }
+      }
+    },
+    "nodeAuthenticationPlugin": {
+      "$ref": "#/$defs/appFwPlugin",
+      "required": [ "filename" ],
+      "properties": {
+        "filename": {
+          "type": "string",
+          "description": "The name of a nodejs file within the /lib directory of the plugin. This file contains a function that is provided with startup context and must contain methods according to its stated capabilities such as authentication and authorization"
+        },
+        "authenticationCategories": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "A short name describing what sort of authentication this plugin can provide, such as LDAP, SAF, etc. If the categories are not known until startup, this info can still be stated at runtime within the javascript code."
+          },
+          "uniqueItems": true
+        }
+      }
+    },
+    "semverVersion": {
+      "type": "string",
+      "description": "A semantic version, see https://semver.org/",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
+    },
+    "semverRange": {
+      "type": "string",
+      "description": "A semantic version, see https://semver.org/",
+      "pattern": "^(([\\^\\~\\>\\<]?)|(>=?)|(<=?))(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
+    },
+    "genericWebContent": {
+      "type": "object",
+      "not": {
+        "anyOf": [
+          { "$ref": "#/$defs/nativeWebContent" },
+          { "$ref": "#/$defs/iframeWebContent" }
+        ]
+      },
+      "description": "A webcontent object without the attributes of an application, such as framework, can be used to just serve a plugin's /web folder from the app-server"
+    },
+    "nativeWebContent": {
+      "$ref": "#/$defs/appWebContent",
+      "description": "A Native application is one that provides a /web/main.js file which can be run within the Zowe Desktop when the user clicks its icon",
+      "properties": {
+        "framework": {
+          "type": "string",
+          "enum": [ "angular2", "angular", "react" ]
+        }
+      }
+    },
+    "iframeWebContent": {
+      "$ref": "#/$defs/appWebContent",
+      "description": "An iframe application is one that provides some html file either within the /web folder or found on another server at runtime, which can be embedded within the Zowe Desktop when the user clicks its icon",
+      "properties": {
+        "framework": {
+          "const": "iframe"
+        },
+        "destination": {
+          "type": "string",
+          "description": "A URL with shell-style ${} subtitutions allowed which states which address the iframe should load."
+        },
+        "startingPage": {
+          "type": "string",
+          "description": "A filename within the /web folder of the plugin, which the iframe should load."
+        },
+        "standaloneUseFramework": {
+          "type": "boolean",
+          "default": false,
+          "description": "When true, iframe apps will be launched within the desktop framework so that features like notifications and app2app communication will function identically to the Desktop. When false, opening the iframe app in a standalone page will have it function like an independent website."
+        }
+      }
+    },
+    "appWebContent": {
+      "type": "object",
+      "description": "A description of an application which can be run within the Zowe Desktop",
+      "required": [ "framework", "launchDefinition", "descriptionKey", "descriptionDefault", "defaultWindowStyle" ],
+      "properties": {
+        "framework": {
+          "type": "string",
+          "enum": [ "angular2", "angular", "react", "iframe" ]
+        },
+        "launchDefinition": {
+          "type": "object",
+          "required": [ "pluginShortNameKey", "pluginShortNameDefault", "imageSrc" ],
+          "properties": {
+            "pluginShortNameKey": {
+              "type": "string",
+              "description": "The internationalization key used to display the application's name in the user's chosen language."
+            },
+            "pluginShortNameDefault": {
+              "type": "string",
+              "description": "The name of the application in the default language. Used as a fallback if the user's chosen language has no translation."
+            },
+            "imageSrc": {
+              "type": "string",
+              "description": "A path relative to and within the 'web' folder of the plugin. This image is used as the application's icon"
+            }
+          }
+        },
+        "descriptionKey": {
+          "type": "string",
+          "description": "The internationalization key used to display the application's description in the user's chosen language."
+        },
+        "descriptionDefault": {
+          "type": "string",
+          "description": "The description of the application in the default language. Used as a fallback if the user's chosen language has no translation."
+        },
+        "isSingleWindowApp": {
+          "type": "boolean",
+          "deprecated": true
+        },
+        "defaultWindowStyle": {
+          "type": "object",
+          "description": "Properties that describe the default visuals of the application window, such as size",
+          "required": [ "width", "height" ],
+          "properties": {
+            "width": {
+              "type": "integer",
+              "minimum": 180,
+              "description": "The width of the Zowe Desktop window of the application when first opened"
+            },
+            "height": {
+              "type": "integer",
+              "minimum": 100,
+              "description": "The height of the Zowe Desktop window of the application when first opened"
+            }
+          }
+        }
+      }
+    },
+    "service": {
+      "type": "object",
+      "required": ["type", "version", "name"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [ "router", "service", "external", "nodeService", "java" ]
+        },
+        "version": {
+          "$ref": "#/$defs/semverVersion"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "externalService": {
+      "$ref": "#/$defs/service",
+      "description": "A proxy service which is hosted from the app-server",
+      "properties": {
+        "type": {
+          "const": "external"
+        },
+        "urlPrefix": {
+          "type": "string"
+        },
+        "isHttps": {
+          "type": "boolean",
+          "deprecated": true,
+          "description": "Specifies if the proxy is to an HTTP or HTTPS server. It is recommended to use a remote.json file within the workspace instead, as pluginDefinition is a read only object"
+        },
+        "host": {
+          "type": "string",
+          "deprecated": true,
+          "description": "Specifies which hostname or IP is being proxied. It is recommended to use a remote.json file within the workspace instead, as pluginDefinition is a read only object",
+          "format": "hostname"
+        },
+        "port": {
+          "type": "integer",
+          "deprecated": true,
+          "description": "Specifies which port is being proxied. It is recommended to use a remote.json file within the workspace instead, as pluginDefinition is a read only object"
+        }
+      }
+    },
+    "routerService": {
+      "$ref": "#/$defs/service",
+      "description": "An ExpressJS router service hosted from the app-server",
+      "required": ["type", "version", "name", "fileName", "routerFactory"],
+      "properties": {
+        "type": {
+          "const": "router"
+        },
+        "initializerLookupMethod": {
+          "type": "string",
+          "enum": ["external"],
+          "deprecated": true
+        },
+        "dependenciesIncluded": {
+          "type": "boolean",
+          "default": true,
+          "deprecated": true
+        },
+        "fileName": {
+          "type": "string",
+          "description": "A javascript file located within the plugin's 'lib' folder which contains the router factory. The router is for a REST or Websocket API that the app-server will include."
+        },
+        "routerFactory": {
+          "type": "string",
+          "description": "The name of a javascript function found in the file specified in 'fileName' which is given plugin context and must return an expressjs router"
+        },
+        "httpCaching": {
+          "type": "boolean",
+          "default": false,
+          "description": "When false, the app-server will add headers to the service response to tell clients not to cache the response"
+        },
+        "internalOnly": {
+          "type": "boolean",
+          "default": false,
+          "description": "When true, the service can only be reached by other services within the same server via the call() function"
+        }
+      }
+    },
+    "nodeService": {
+      "$ref": "#/$defs/service",
+      "description": "A nodejs callback service that acts upon expressjs request and response objects. It runs within the app-server",
+      "required": ["type", "version", "name", "fileName", "methods", "handlerInstaller"],
+      "deprecated": true,
+      "properties": {
+        "type": {
+          "const": "nodeService"
+        },
+        "initializerLookupMethod": {
+          "type": "string",
+          "enum": [ "external" ]
+        },
+        "dependenciesIncluded": {
+          "type": "boolean",
+          "default": true,
+          "deprecated": true
+        },
+        "fileName": {
+          "type": "string",
+          "description": "A javascript file located within the plugin's 'lib' folder which contains the handler factory. The handler is for a REST or Websocket API that the app-server will include."
+        },
+        "handlerInstaller": {
+          "type": "string",
+          "description": "The name of a javascript function found in the file specified in 'fileName' which is given plugin context and must return a callback function"
+        },
+        "methods": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [ "GET", "PUT", "POST", "DELETE", "OPTIONS", "HEAD" ],
+            "description": "A list of HTTP methods this service will respond to"
+          },
+          "uniqueItems": true
+        }
+      }
+    },
+    "serviceService": {
+      "$ref": "#/$defs/service",
+      "description": "A service that runs within ZSS. It uses a callback written in C that recieves a request and response struct",
+      "required": ["type", "version", "name", "methods", "initializerName"],
+      "properties": {
+        "type": {
+          "const": "service"
+        },
+        "initializerLookupMethod": {
+          "type": "string",
+          "enum": ["external", "internal"],
+          "deprecated": false
+        },
+        "dependenciesIncluded": {
+          "type": "boolean",
+          "default": true,
+          "deprecated": true
+        },
+        "libraryName": {
+          "type": "string",
+          "description": "The path of a 31-bit or 64-bit DLL file relative to and within the plugin's 'lib' folder. It contains a REST or Websocket API that the agent will include."
+        },
+        "libraryName31": {
+          "type": "string",
+          "description": "The path of a 31-bit DLL file relative to and within the plugin's 'lib' folder. It contains a REST or Websocket API that the agent will include."
+        },
+        "libraryName64": {
+          "type": "string",
+          "description": "The path of a 64-bit DLL file relative to and within the plugin's 'lib' folder. It contains a REST or Websocket API that the agent will include."
+        },
+        "methods": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [ "GET", "PUT", "POST", "DELETE" ],
+            "description": "A list of HTTP methods this service will respond to"
+          },
+          "uniqueItems": true
+        },
+        "initializerName": {
+          "type": "string",
+          "description": "The function name that will be called with plugin context to add the service routes to the agent"
+        }
+      }
+    },
+    "importService": {
+      "type": "object",
+      "description": "A service which points to another service. The app-server will setup a URL which calls the source when accessed",
+      "required": [ "type", "sourceName", "localName", "sourcePlugin", "versionRange" ],
+      "properties": {
+        "type": {
+          "const": "import"
+        },
+        "sourceName": {
+          "type": "string",
+          "description": "The name of the service being imported"
+        },
+        "localName": {
+          "type": "string",
+          "description": "The name of this service within this plugin"
+        },
+        "sourcePlugin": {
+          "$ref": "#/$defs/reverseDomainNotation",
+          "description": "The ID of the plugin where the service is being imported from"
+        },
+        "versionRange": {
+          "$ref": "#/$defs/semverRange",
+          "description": "A semver range that describes which version of the service to import"
+        }
+      }
+    }
+  }
+}

--- a/schema/plugindefinition-schema.json
+++ b/schema/plugindefinition-schema.json
@@ -16,10 +16,19 @@
       "type": "string",
       "pattern": "^[A-Za-z]{2,6}((?!-)\\.[A-Za-z0-9-]{1,63}(?<!-))+$"
     },
+    "semverVersion": {
+      "type": "string",
+      "description": "A semantic version, see https://semver.org/",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
+    },
+    "semverRange": {
+      "type": "string",
+      "description": "A semantic version, see https://semver.org/",
+      "pattern": "^(([\\^\\~\\>\\<]?)|(>=?)|(<=?))(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
+    },
     "appFwPlugin": {
       "type": "object",
       "required": ["identifier", "apiVersion", "pluginVersion", "pluginType"],
-      "additionalProperties": true,
       "propeties": {
         "identifier": {
           "$ref": "#/$defs/reverseDomainNotation",
@@ -51,7 +60,8 @@
         },
         "requirements": {
           "type": "object",
-          "description": "TODO",
+          "description": "Defining a list of requirements lets the app-server decide if your plugin should or should not be loaded according to if requirements are met in the environment.",
+          "additionalProperties": false,
           "properties": {
             "components": {
               "type": "object",
@@ -115,8 +125,27 @@
         }
       }
     },
+    "libraryPlugin": {
+      "$ref": "#/$defs/appFwPlugin",
+      "description": "Library plugins are used for hosting static web content",
+      "deprecated": true,
+      "additionalProperties": false,
+      "properties": {
+        "pluginType": {
+          "const": "library"
+        },
+        "libraryName": {
+          "type": "string"
+        },
+        "libraryVersion": {
+          "$ref": "#/$devs/semverVersion"
+        }        
+      }
+    },
     "bootstrapPlugin": {
       "$ref": "#/$defs/appFwPlugin",
+      "description": "Only one bootstrap plugin per server is intended, and its role is to bootstrap Desktop-type plugins for browser use",
+      "additionalProperties": false,
       "properties": {
         "pluginType": {
           "const": "bootstrap"
@@ -128,6 +157,8 @@
     },
     "desktopPlugin": {
       "$ref": "#/$defs/appFwPlugin",
+      "description": "Desktop plugins are webcontent which embeds application-type plugins within a web browser, regardless of if resembles a 'desktop' or not.",
+      "additionalProperties": false,
       "properties": {
         "pluginType": {
           "const": "desktop"
@@ -139,6 +170,8 @@
     },
     "applicationPlugin": {
       "$ref": "#/$defs/appFwPlugin",
+      "description": "Application plugins contain web content and/or network APIs which are compatible with embedding in a Desktop plugin web page, but may also be used by themselves",
+      "additionalProperties": false,
       "properties": {
         "pluginType": {
           "const": "application"
@@ -160,7 +193,9 @@
     },
     "nodeAuthenticationPlugin": {
       "$ref": "#/$defs/appFwPlugin",
+      "description": "The app-server delegates to these plugins for user permission management tasks such as authentication and authorization",
       "required": [ "filename" ],
+      "additionalProperties": false,
       "properties": {
         "filename": {
           "type": "string",
@@ -176,16 +211,6 @@
         }
       }
     },
-    "semverVersion": {
-      "type": "string",
-      "description": "A semantic version, see https://semver.org/",
-      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
-    },
-    "semverRange": {
-      "type": "string",
-      "description": "A semantic version, see https://semver.org/",
-      "pattern": "^(([\\^\\~\\>\\<]?)|(>=?)|(<=?))(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
-    },
     "genericWebContent": {
       "type": "object",
       "not": {
@@ -199,6 +224,7 @@
     "nativeWebContent": {
       "$ref": "#/$defs/appWebContent",
       "description": "A Native application is one that provides a /web/main.js file which can be run within the Zowe Desktop when the user clicks its icon",
+      "additionalProperties": false,
       "properties": {
         "framework": {
           "type": "string",
@@ -209,18 +235,21 @@
     "iframeWebContent": {
       "$ref": "#/$defs/appWebContent",
       "description": "An iframe application is one that provides some html file either within the /web folder or found on another server at runtime, which can be embedded within the Zowe Desktop when the user clicks its icon",
+      "additionalProperties": false,
       "properties": {
         "framework": {
           "const": "iframe"
         },
-        "destination": {
-          "type": "string",
-          "description": "A URL with shell-style ${} subtitutions allowed which states which address the iframe should load."
-        },
-        "startingPage": {
-          "type": "string",
-          "description": "A filename within the /web folder of the plugin, which the iframe should load."
-        },
+        "oneOf": [
+          "destination": {
+            "type": "string",
+            "description": "A URL with shell-style ${} subtitutions allowed which states which address the iframe should load."
+          },
+          "startingPage": {
+            "type": "string",
+            "description": "A filename within the /web folder of the plugin, which the iframe should load."
+          }
+        ],
         "standaloneUseFramework": {
           "type": "boolean",
           "default": false,
@@ -232,6 +261,7 @@
       "type": "object",
       "description": "A description of an application which can be run within the Zowe Desktop",
       "required": [ "framework", "launchDefinition", "descriptionKey", "descriptionDefault", "defaultWindowStyle" ],
+      "additionalProperties": false,
       "properties": {
         "framework": {
           "type": "string",
@@ -288,6 +318,7 @@
     },
     "service": {
       "type": "object",
+      "description": "A part of a plugin which adds a network API to a server such as a REST or websocket API",
       "required": ["type", "version", "name"],
       "properties": {
         "type": {
@@ -305,6 +336,7 @@
     "externalService": {
       "$ref": "#/$defs/service",
       "description": "A proxy service which is hosted from the app-server",
+      "additionalProperties": false,
       "properties": {
         "type": {
           "const": "external"
@@ -334,6 +366,7 @@
       "$ref": "#/$defs/service",
       "description": "An ExpressJS router service hosted from the app-server",
       "required": ["type", "version", "name", "fileName", "routerFactory"],
+      "additionalProperties": false,
       "properties": {
         "type": {
           "const": "router"
@@ -373,6 +406,7 @@
       "description": "A nodejs callback service that acts upon expressjs request and response objects. It runs within the app-server",
       "required": ["type", "version", "name", "fileName", "methods", "handlerInstaller"],
       "deprecated": true,
+      "additionalProperties": false,
       "properties": {
         "type": {
           "const": "nodeService"
@@ -409,12 +443,14 @@
       "$ref": "#/$defs/service",
       "description": "A service that runs within ZSS. It uses a callback written in C that recieves a request and response struct",
       "required": ["type", "version", "name", "methods", "initializerName"],
+      "additionalProperties": false,
       "properties": {
         "type": {
           "const": "service"
         },
         "initializerLookupMethod": {
           "type": "string",
+          "description": "States whether the service is to be found as a plugin or is built-in to ZSS already",
           "enum": ["external", "internal"],
           "deprecated": false
         },
@@ -454,6 +490,7 @@
       "type": "object",
       "description": "A service which points to another service. The app-server will setup a URL which calls the source when accessed",
       "required": [ "type", "sourceName", "localName", "sourcePlugin", "versionRange" ],
+      "additionalProperties": false,
       "properties": {
         "type": {
           "const": "import"


### PR DESCRIPTION
Signed-off-by: 1000turquoisepogs <sgrady@rocketsoftware.com>

<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

This PR is related to https://github.com/zowe/zlux/issues/778 but https://github.com/zowe/zlux/issues/789 still needs to be decided upon, so these files could move again.

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## Testing
This still needs testing, as I'm unsure if this schema works as intended when it comes to adding properties on top of a $ref or having a catch-all properties pattern and then having exceptions for specifically-defined properties.

## Further comments
These files may be further changed as we learn how they must be associated with the zowe base schema and zowe server infrastructure validation code in general (see https://github.com/zowe/zowe-install-packaging/pull/2686 )
It could be that these files $ref the zowe base one in some way, and these files may even be wrapped in a few ways to fit into the manifest schema and server schema